### PR TITLE
不合法参数原样返回

### DIFF
--- a/libs/kmbt.js
+++ b/libs/kmbt.js
@@ -14,7 +14,7 @@ const SPLIT_NUMBER = Math.pow(10, SPLIT_COUNT)
  */
 export default function (value, fixed = 2) {
   const num = parseNumber(value)
-  if (!num) return ''
+  if (!num) return value
   // 整数部分有多少个 3 位
   const count = Math.min(Math.ceil(num.integer.length / SPLIT_COUNT), KMB_CEILING) - 1
   return Number((value / Math.pow(SPLIT_NUMBER, count)).toFixed(fixed)) + KMB_MAP[count]

--- a/libs/percentage.js
+++ b/libs/percentage.js
@@ -6,9 +6,9 @@ import isNumber from './isNumber'
  * @param {number} [fixed=2]
  * @return {string}
  */
-export default function (number, fixed = 2) {
-  number = Number(number)
-  if (!isNumber(number)) return ''
+export default function (value, fixed = 2) {
+  const number = Number(value)
+  if (!isNumber(number)) return value
   let numberString = (number * 100).toFixed(fixed)
   return parseFloat(numberString) + '%'
 }

--- a/libs/thousands.js
+++ b/libs/thousands.js
@@ -11,7 +11,7 @@ const COUNT = 3
  */
 export default function (value) {
   const num = parseNumber(value)
-  if (!num) return ''
+  if (!num) return value
   const {
     minus,
     integer,

--- a/test/kmbt-spec.js
+++ b/test/kmbt-spec.js
@@ -2,7 +2,7 @@ const { kmbt } = require('../dist/nosh.common')
 
 describe('kmbt 函数', function () {
   it('能正常运行', function () {
-    expect(kmbt('not a number')).toBe('')
+    expect(kmbt('not a number')).toBe('not a number')
     expect(kmbt(-988)).toBe('-988')
     expect(kmbt(988)).toBe('988')
     expect(kmbt(988.01)).toBe('988.01')

--- a/test/percentage-spec.js
+++ b/test/percentage-spec.js
@@ -2,7 +2,7 @@ const { percentage } = require('../dist/nosh.common')
 
 describe('percentage 函数', function () {
   it('能正常运行', function () {
-    expect(percentage('not a number')).toBe('')
+    expect(percentage('not a number')).toBe('not a number')
     expect(percentage('1')).toBe('100%')
     expect(percentage(-0.1)).toBe('-10%')
     expect(percentage(0.01, 4)).toBe('1%')

--- a/test/thousands-spec.js
+++ b/test/thousands-spec.js
@@ -2,7 +2,7 @@ const { thousands } = require('../dist/nosh.common')
 
 describe('thousands 函数', function () {
   it('能正常运行', function () {
-    expect(thousands('not a number')).toBe('')
+    expect(thousands('not a number')).toBe('not a number')
     expect(thousands(1000)).toBe('1,000')
     expect(thousands(-1000)).toBe('-1,000')
   })


### PR DESCRIPTION
`thousands` 目前处理不能解析成 `number` 的参数时时返回 `''`:

```javascrip
thousands('-') // output ''
```

我认为不合法的输入原样返回比较好，因为在数据展示可能会有很多不同方式表示空值，如：`-` `暂无数据` `空` 这样一类的，这样的不合法参数原样输出会合适一点。