### PR TITLE
feat(obj2qs): optional prefix for `?` or `&`

### DIFF
--- a/libs/obj2qs.js
+++ b/libs/obj2qs.js
@@ -2,15 +2,16 @@ const { hasOwnProperty } = Object.prototype
 
 /**
  * 将一个对象转换成查询字符串
- * @param obj
+ * @param {object} obj
+ * @param {string} [prefix]
  * @return {string}
  */
-export default function (obj) {
+export default function (obj, prefix = '') {
   const qs = []
   for (let key in obj) {
     if (hasOwnProperty.call(obj, key)) {
       qs.push(key + '=' + encodeURIComponent(obj[key]))
     }
   }
-  return qs.join('&')
+  return prefix + qs.join('&')
 }

--- a/test/obj2qs-spec.js
+++ b/test/obj2qs-spec.js
@@ -1,7 +1,13 @@
 const { obj2qs } = require('../dist/nosh.common')
 
 describe('obj2qs 函数', function () {
-  it('能正常运行', function () {
+  it('参数拼接', function () {
     expect(obj2qs({ a: 'a', b: 'b' })).toBe('a=a&b=b')
+  })
+  it('参数拼接加 ? 前缀', function () {
+    expect(obj2qs({ apple: 'jack', rainbow: 'dash' }, '?')).toBe('?apple=jack&rainbow=dash')
+  })
+  it('参数拼接加 & 前缀', function () {
+    expect(obj2qs({ twilight: 'Sparkle', pinkie: 'pie' }, '&')).toBe('&twilight=sparkle&pinkie=pie')
   })
 })

--- a/test/obj2qs-spec.js
+++ b/test/obj2qs-spec.js
@@ -8,6 +8,6 @@ describe('obj2qs 函数', function () {
     expect(obj2qs({ apple: 'jack', rainbow: 'dash' }, '?')).toBe('?apple=jack&rainbow=dash')
   })
   it('参数拼接加 & 前缀', function () {
-    expect(obj2qs({ twilight: 'Sparkle', pinkie: 'pie' }, '&')).toBe('&twilight=sparkle&pinkie=pie')
+    expect(obj2qs({ twilight: 'sparkle', pinkie: 'pie' }, '&')).toBe('&twilight=sparkle&pinkie=pie')
   })
 })


### PR DESCRIPTION
When using the util function, you always have to add a prefix:

```js
// either
url += '&' + obj2qs(query)
// or
url += '?' + obj2qs(query)
```

This PR makes it slightly clearer, such that clarifying the prefix is part of the query string.

P.S. If introduced as a breaking change, recommend to choose either `?` or `&` as the default value, rather than empty string.